### PR TITLE
This file says "contect" but I cannot find any reference to that bein…

### DIFF
--- a/web_fingerprint/microsoft-exchange.yaml
+++ b/web_fingerprint/microsoft-exchange.yaml
@@ -65,7 +65,7 @@ fingerprint:
     status_code: 0
     headers: {}
     keyword:
-      - <meta http-equiv="refresh" contect="0;url=/owa">
+      - <meta http-equiv="refresh" content="0;url=/owa">
     favicon_hash: []
   - path: /
     request_method: get


### PR DESCRIPTION
[This file says "contect" but I cannot find any reference to that being a legitimate string for OWA meta redirects.

I believe it's supposed to be "content" which would be the standard for meta refresh tags.