### PR TITLE
Update xxl-job.yaml

### DIFF
--- a/web-fingerprint/xuxueli/xxl-job.yaml
+++ b/web-fingerprint/xuxueli/xxl-job.yaml
@@ -7,7 +7,7 @@ info:
   metadata:
     fofa-query:
     - icon_hash=1691956220
-    product: xxl-job
+    product: xxljob
     shodan-query:
     - http.favicon.hash:1691956220
     vendor: xuxueli


### PR DESCRIPTION
nuclei扫描xxl-job，其中nuclei的tags是xxljob
xxl-job.yaml模版的product应该设置为xxljob
```yaml
id: xxljob-default-login

info:
  name: XXL-JOB Default Login
  author: pdteam,ritikchaddha
  severity: high
  description: XXL-JOB default admin credentials were discovered.
  reference:
    - https://github.com/xuxueli/xxl-job
  classification:
    cvss-metrics: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L
    cvss-score: 8.3
    cwe-id: CWE-522
  metadata:
    verified: true
    max-request: 2
    shodan-query: http.favicon.hash:1691956220
    product: xxl-job
    vendor: xuxueli
    fofa-query: icon_hash=1691956220
  tags: default-login,xxljob
```