### PR TITLE
Add code-server (Coder) web fingerprint

### DIFF
--- a/web-fingerprint/coder/code-server.yaml
+++ b/web-fingerprint/coder/code-server.yaml
@@ -1,0 +1,27 @@
+id: code-server
+info:
+  name: code-server
+  author: Ruashots
+  tags: detect,tech,code-server
+  severity: info
+  metadata:
+    product: code-server
+    shodan-query:
+    - http.html:"telemetry.coder.com"
+    vendor: coder
+    verified: true
+http:
+- method: GET
+  path:
+  - '{{BaseURL}}/'
+  matchers:
+  - type: word
+    words:
+    - telemetry.coder.com
+    case-insensitive: true
+  - type: word
+    words:
+    - code-server
+    - /_static/
+    condition: and
+    case-insensitive: true


### PR DESCRIPTION
Adds a web fingerprint for **code-server** ([coder/code-server](https://github.com/coder/code-server)) — the VS Code IDE served in the browser, common in self-hosted setups.

code-server serves a JS app shell, so it isn't identifiable by the `Server` header or `<title>` alone. This rule keys on stable markers in the served HTML body:
- the Coder telemetry endpoint `telemetry.coder.com`, and
- the `code-server` product string together with its `/_static/` asset prefix (`condition: and`).

Verified against a live code-server instance (both matchers fire) and confirmed it does not match an unrelated self-hosted web UI.