### PR TITLE
Add FlareSolverr web fingerprint

### DIFF
--- a/web-fingerprint/flaresolverr/flaresolverr.yaml
+++ b/web-fingerprint/flaresolverr/flaresolverr.yaml
@@ -1,0 +1,21 @@
+id: flaresolverr
+info:
+  name: flaresolverr
+  author: Ruashots
+  tags: detect,tech,flaresolverr
+  severity: info
+  metadata:
+    product: flaresolverr
+    shodan-query:
+    - http.html:"FlareSolverr is ready"
+    vendor: flaresolverr
+    verified: true
+http:
+- method: GET
+  path:
+  - '{{BaseURL}}/'
+  matchers:
+  - type: word
+    words:
+    - FlareSolverr is ready
+    case-insensitive: true


### PR DESCRIPTION
Adds a fingerprint for **FlareSolverr** (https://github.com/FlareSolverr/FlareSolverr), a proxy server to bypass Cloudflare/DDoS-Guard, very common alongside *arr media stacks.

It has no `<title>` and runs on a generic `waitress` WSGI server, so it's only identifiable by its response body — `GET /` returns `{"msg":"FlareSolverr is ready!",...}`. This keys on the distinctive `FlareSolverr is ready` body string.

Verified against a live instance (matches), and confirmed it does not match an unrelated app's page.