### PR TITLE
Add Immich web fingerprint

### DIFF
--- a/web-fingerprint/immich/immich.yaml
+++ b/web-fingerprint/immich/immich.yaml
@@ -1,0 +1,23 @@
+id: immich
+info:
+  name: immich
+  author: Ruashots
+  tags: detect,tech,immich
+  severity: info
+  metadata:
+    product: immich
+    shodan-query:
+    - http.html:"bg-immich-bg"
+    vendor: immich
+    verified: true
+http:
+- method: GET
+  path:
+  - '{{BaseURL}}/'
+  matchers:
+  - type: word
+    words:
+    - immich
+    - /_app/immutable
+    condition: and
+    case-insensitive: true


### PR DESCRIPTION
Adds a fingerprint for **Immich** (https://github.com/immich-app/immich), one of the most widely-deployed self-hosted apps (photo/video management) — currently unidentified.

Immich's web UI (default port 2283) is a SvelteKit SPA: no `<title>`, no `Server` header — so it's only identifiable by its response body, which is saturated with Immich-specific markers (`bg-immich-bg`, `bg-immich-dark-bg`, "To use Immich, you must enable JavaScript"). This keys on `immich` + the SvelteKit `/_app/immutable` path (AND) to stay specific.

Verified against a live Immich instance (matches) and confirmed it does not match an unrelated SvelteKit/Node app.